### PR TITLE
Feature - simplified deployement adding helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modern Kubernetes monitoring solution with an intelligent agent that collects 
 ## ✨ Features
 
 ### 🕵️ Agent
+
 - **Smart Discovery**: Automatically discovers all namespaces and resources
 - **Resource Monitoring**: Tracks pods, deployments, and services in real-time
 - **Performance Metrics**: Collects CPU and memory usage data
@@ -18,6 +19,7 @@ A modern Kubernetes monitoring solution with an intelligent agent that collects 
 - **Kubernetes Native**: Runs as a pod with proper RBAC permissions
 
 ### 📊 Dashboard
+
 - **Real-time Updates**: Live data refresh every 30 seconds
 - **Cluster Overview**: High-level statistics and resource counts
 - **Namespace Explorer**: Interactive drill-down into namespaces and resources
@@ -52,6 +54,7 @@ A modern Kubernetes monitoring solution with an intelligent agent that collects 
 ### Local Development
 
 1. **Clone and setup:**
+
    ```bash
    git clone https://github.com/thekubefleet/kubefleet.git
    cd kubefleet
@@ -59,22 +62,26 @@ A modern Kubernetes monitoring solution with an intelligent agent that collects 
    ```
 
 2. **Generate protobuf code:**
+
    ```bash
    protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative proto/agent.proto
    ```
 
 3. **Start the dashboard server:**
+
    ```bash
    go run ./cmd/server
    ```
 
 4. **Start the React development server:**
+
    ```bash
    cd dashboard
    npm start
    ```
 
 5. **Run the agent (in another terminal):**
+
    ```bash
    go run ./cmd/agent
    ```
@@ -95,6 +102,27 @@ kubectl apply -f deploy/agent-deployment.yaml
 # Access the dashboard
 kubectl port-forward svc/kubefleet-dashboard 3000:3000
 ```
+
+### Helm Deployment
+
+1. **Install metrics-server (required for CPU/memory metrics):**
+
+   ```bash
+   helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+   helm repo update metrics-server
+   helm upgrade -i metrics-server metrics-server/metrics-server -n kube-system --set args={--kubelet-insecure-tls}
+   ```
+
+2. **Install KubeFleet using Helm chart:**
+
+   ```bash
+   helm upgrade -i kubefleet ./charts/kubefleet -n kubefleet --create-namespace
+   ```
+
+3. **Access the dashboard locally:**
+   ```bash
+   kubectl -n kubefleet port-forward svc/kubefleet-dashboard 3000:3000
+   ```
 
 ## 📁 Project Structure
 
@@ -124,15 +152,18 @@ kubefleet/
 ### Environment Variables
 
 **Agent:**
+
 - `KUBEFLEET_SERVER_ADDR`: gRPC server address (default: localhost:50051)
 
 **Dashboard Server:**
+
 - `HTTP_PORT`: HTTP server port (default: 3000)
 - `GRPC_PORT`: gRPC server port (default: 50051)
 
 ### RBAC Permissions
 
 The agent requires the following permissions:
+
 - Read access to namespaces, pods, services, and deployments
 - Read access to metrics API (if available)
 
@@ -201,6 +232,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
    - Check browser console for errors
 
 #### No metrics available / "the server could not find the requested resource (get pods.metrics.k8s.io)"
+
 - Ensure metrics-server is installed in your cluster:
   ```sh
   kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml

--- a/charts/kubefleet/.helmignore
+++ b/charts/kubefleet/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.git/
+.gitignore
+.DS_Store
+*.swp
+*.tmp
+*.orig
+*.rej

--- a/charts/kubefleet/Chart.yaml
+++ b/charts/kubefleet/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kubefleet
+description: Helm chart for deploying the KubeFleet dashboard and agent
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/kubefleet/README.md
+++ b/charts/kubefleet/README.md
@@ -1,0 +1,42 @@
+# KubeFleet Helm Chart
+
+This chart deploys the full KubeFleet application:
+
+- `kubefleet-dashboard` Deployment + Service (+ optional Ingress)
+- `kubefleet-agent` Deployment
+- Agent ServiceAccount + ClusterRole + ClusterRoleBinding
+
+## Prerequisite: metrics-server
+
+KubeFleet reads CPU and memory usage from Kubernetes Metrics API. Install metrics-server first:
+
+```bash
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+helm repo update metrics-server
+helm upgrade -i metrics-server metrics-server/metrics-server -n kube-system --set args={--kubelet-insecure-tls}
+```
+
+## Install
+
+```bash
+helm upgrade -i kubefleet ./charts/kubefleet -n kubefleet --create-namespace
+```
+
+## Useful values
+
+- `agent.image.repository`, `agent.image.tag`
+- `dashboard.image.repository`, `dashboard.image.tag`
+- `dashboard.ingress.enabled`
+- `dashboard.ingress.host`
+- `namespaceOverride`
+
+## Example custom install
+
+```bash
+helm upgrade -i kubefleet ./charts/kubefleet \
+  -n kubefleet --create-namespace \
+  --set dashboard.ingress.enabled=true \
+  --set dashboard.ingress.host=kubefleet.example.com \
+  --set agent.image.repository=ghcr.io/thekubefleet/kubefleet-agent \
+  --set dashboard.image.repository=ghcr.io/thekubefleet/kubefleet-dashboard
+```

--- a/charts/kubefleet/templates/NOTES.txt
+++ b/charts/kubefleet/templates/NOTES.txt
@@ -1,0 +1,10 @@
+KubeFleet has been deployed.
+
+Dashboard service:
+  kubectl get svc {{ include "kubefleet.dashboardName" . }} -n {{ include "kubefleet.namespace" . }}
+
+Port-forward dashboard locally:
+  kubectl port-forward svc/{{ include "kubefleet.dashboardName" . }} 3000:{{ .Values.dashboard.service.httpPort }} -n {{ include "kubefleet.namespace" . }}
+
+If you enabled ingress, add this host to DNS or /etc/hosts:
+  {{ .Values.dashboard.ingress.host }}

--- a/charts/kubefleet/templates/_helpers.tpl
+++ b/charts/kubefleet/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{- define "kubefleet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kubefleet.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" (include "kubefleet.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubefleet.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{- define "kubefleet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kubefleet.labels" -}}
+helm.sh/chart: {{ include "kubefleet.chart" . }}
+app.kubernetes.io/name: {{ include "kubefleet.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "kubefleet.agentName" -}}
+{{- printf "%s-agent" (include "kubefleet.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kubefleet.dashboardName" -}}
+{{- printf "%s-dashboard" (include "kubefleet.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kubefleet.agentServiceAccountName" -}}
+{{- if .Values.agent.serviceAccount.create -}}
+{{- default (include "kubefleet.agentName" .) .Values.agent.serviceAccount.name -}}
+{{- else -}}
+{{- required "agent.serviceAccount.name is required when agent.serviceAccount.create is false" .Values.agent.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kubefleet/templates/agent-deployment.yaml
+++ b/charts/kubefleet/templates/agent-deployment.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.agent.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubefleet.agentName" . }}
+  namespace: {{ include "kubefleet.namespace" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+spec:
+  replicas: {{ .Values.agent.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kubefleet.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kubefleet.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: agent
+    spec:
+      serviceAccountName: {{ include "kubefleet.agentServiceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          env:
+            - name: KUBEFLEET_SERVER_ADDR
+              value: {{ default (printf "%s:%v" (include "kubefleet.dashboardName" .) .Values.dashboard.service.grpcPort) .Values.agent.serverAddress | quote }}
+          resources:
+            {{- toYaml .Values.agent.resources | nindent 12 }}
+{{- end }}

--- a/charts/kubefleet/templates/agent-serviceaccount.yaml
+++ b/charts/kubefleet/templates/agent-serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.agent.enabled .Values.agent.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubefleet.agentServiceAccountName" . }}
+  namespace: {{ include "kubefleet.namespace" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+  {{- with .Values.agent.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubefleet/templates/dashboard-deployment.yaml
+++ b/charts/kubefleet/templates/dashboard-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubefleet.dashboardName" . }}
+  namespace: {{ include "kubefleet.namespace" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  replicas: {{ .Values.dashboard.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kubefleet.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kubefleet.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: dashboard
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dashboard
+          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.dashboard.service.httpPort }}
+              name: http
+            - containerPort: {{ .Values.dashboard.service.grpcPort }}
+              name: grpc
+          env:
+            - name: HTTP_PORT
+              value: {{ .Values.dashboard.env.httpPort | quote }}
+            - name: GRPC_PORT
+              value: {{ .Values.dashboard.env.grpcPort | quote }}
+          resources:
+            {{- toYaml .Values.dashboard.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.dashboard.livenessProbe.path }}
+              port: {{ .Values.dashboard.service.httpPort }}
+            initialDelaySeconds: {{ .Values.dashboard.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dashboard.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.dashboard.readinessProbe.path }}
+              port: {{ .Values.dashboard.service.httpPort }}
+            initialDelaySeconds: {{ .Values.dashboard.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dashboard.readinessProbe.periodSeconds }}
+{{- end }}

--- a/charts/kubefleet/templates/dashboard-service.yaml
+++ b/charts/kubefleet/templates/dashboard-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubefleet.dashboardName" . }}
+  namespace: {{ include "kubefleet.namespace" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "kubefleet.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: dashboard
+  ports:
+    - name: http
+      port: {{ .Values.dashboard.service.httpPort }}
+      targetPort: {{ .Values.dashboard.service.httpPort }}
+    - name: grpc
+      port: {{ .Values.dashboard.service.grpcPort }}
+      targetPort: {{ .Values.dashboard.service.grpcPort }}
+{{- end }}

--- a/charts/kubefleet/templates/ingress.yaml
+++ b/charts/kubefleet/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kubefleet.dashboardName" . }}-ingress
+  namespace: {{ include "kubefleet.namespace" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+  {{- with .Values.dashboard.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.dashboard.ingress.className }}
+  ingressClassName: {{ .Values.dashboard.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.dashboard.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.dashboard.ingress.path }}
+            pathType: {{ .Values.dashboard.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "kubefleet.dashboardName" . }}
+                port:
+                  number: {{ .Values.dashboard.service.httpPort }}
+{{- end }}

--- a/charts/kubefleet/templates/rbac.yaml
+++ b/charts/kubefleet/templates/rbac.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.agent.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubefleet.agentName" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "services"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubefleet.agentName" . }}
+  labels:
+    {{- include "kubefleet.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubefleet.agentServiceAccountName" . }}
+    namespace: {{ include "kubefleet.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kubefleet.agentName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/kubefleet/values.yaml
+++ b/charts/kubefleet/values.yaml
@@ -1,0 +1,68 @@
+nameOverride: ""
+fullnameOverride: ""
+
+namespaceOverride: ""
+
+imagePullSecrets: []
+
+agent:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: kubefleet-agent
+    tag: latest
+    pullPolicy: IfNotPresent
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+  # Leave empty to auto-target the dashboard service in this chart release.
+  serverAddress: ""
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
+
+dashboard:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: kubefleet-dashboard
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    httpPort: 3000
+    grpcPort: 50051
+  env:
+    httpPort: "3000"
+    grpcPort: "50051"
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+  livenessProbe:
+    path: /api/health
+    initialDelaySeconds: 30
+    periodSeconds: 10
+  readinessProbe:
+    path: /api/health
+    initialDelaySeconds: 5
+    periodSeconds: 5
+  ingress:
+    enabled: false
+    className: ""
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    host: kubefleet-dashboard.local
+    path: /
+    pathType: Prefix
+
+rbac:
+  create: true


### PR DESCRIPTION
## Description
This PR adds an official Helm chart to deploy the full KubeFleet application and updates documentation with Helm-based install instructions.

### What was added
- Helm chart for full app deployment:
  - Agent Deployment
  - Dashboard Deployment
  - Dashboard Service
  - Optional Ingress
  - Agent ServiceAccount
  - Agent ClusterRole and ClusterRoleBinding
- Configurable chart values for images, ports, resources, namespace override, and ingress
- Helm chart usage docs
- Main README updates with Helm deployment steps and metrics-server prerequisite
- Local Minikube validation and image pull workflow guidance

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Validation performed:
- helm lint on the chart (passed, no failures)
- helm template render (successful render)
- Runtime verification on Minikube with both pods running

Local Minikube test flow:
- Build images in Minikube Docker environment
- Deploy/upgrade with Helm
- Verify pod readiness and service availability

- [x] Test A: Helm lint and template validation
- [x] Test B: Minikube deployment verification

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Not applicable (infrastructure and documentation changes).

## Additional Notes
For local clusters like Minikube, image pull errors were resolved by building images in the cluster runtime and setting image pull policy to Never during local testing.